### PR TITLE
Changed xmm.git path in submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "xmm"]
 	path = xmm
-	url = https://github.com/JulesFrancoise/xmm.git
+	url = https://github.com/Ircam-RnD/xmm.git
 	ignore = dirty


### PR DESCRIPTION
The old submodule path is broken so git submodule init doesn't work anymore.